### PR TITLE
Use comma-ok type assertion for UserObject in connection handlers

### DIFF
--- a/main.go
+++ b/main.go
@@ -593,7 +593,13 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 
 			// Retrieve the UserObject stored by the completion function
 			if uo, exists := sharedState["UserObject"]; exists {
-				userObject = uo.(*users.UserRecord)
+				var ok bool
+				userObject, ok = uo.(*users.UserRecord)
+				if !ok {
+					mudlog.Error("UserObject type assertion failed", "connectionId", clientInput.ConnectionId)
+					connections.Remove(clientInput.ConnectionId)
+					break
+				}
 				// Remove it from shared state if no longer needed there
 				delete(sharedState, "UserObject")
 			} else {
@@ -837,7 +843,13 @@ func HandleWebSocketConnection(conn *websocket.Conn) {
 
 			// Retrieve the UserObject stored by the completion function
 			if uo, exists := sharedState["UserObject"]; exists {
-				userObject = uo.(*users.UserRecord)
+				var ok bool
+				userObject, ok = uo.(*users.UserRecord)
+				if !ok {
+					mudlog.Error("UserObject type assertion failed", "connectionId", clientInput.ConnectionId)
+					connections.Remove(clientInput.ConnectionId)
+					break
+				}
 				// Remove it from shared state if no longer needed there
 				delete(sharedState, "UserObject")
 			} else {


### PR DESCRIPTION
## Summary
Replaces direct type assertions with comma-ok form in both telnet and WebSocket connection handlers to prevent panics.

## Changes
- `main.go`: Both `handleTelnetConnection` and `HandleWebSocketConnection` used `uo.(*users.UserRecord)` on a value from `map[string]any`. Changed to comma-ok form with graceful error handling (log, disconnect, break).

## Test plan
- [x] `go build` passes
- [x] Full test suite passes (pre-existing flaky test in procedural/ unrelated — #39)

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)