### PR TITLE
Add internal authorization check to system commands

### DIFF
--- a/internal/inputhandlers/systemcommands.go
+++ b/internal/inputhandlers/systemcommands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/users"
 )
 
 func SystemCommandInputHandler(clientInput *connections.ClientInput, sharedState map[string]any) (nextHandler bool) {
@@ -106,6 +107,15 @@ func trySystemCommand(cmd string, connectionId connections.ConnectionId) bool {
 	// look for cmd in the command list
 	if _, ok := systemCommandList[cmd]; !ok {
 		return false
+	}
+
+	// /quit is allowed for all users. Privileged commands require admin role.
+	if cmd != "quit" {
+		user := users.GetByConnectionId(connectionId)
+		if user == nil || user.Role != users.RoleAdmin {
+			mudlog.Warn("Unauthorized system command attempt", "cmd", cmd, "connectionId", connectionId)
+			return false
+		}
 	}
 
 	mudlog.Info("System Command", "cmd", cmd, "arg", arg)

--- a/internal/inputhandlers/systemcommands_test.go
+++ b/internal/inputhandlers/systemcommands_test.go
@@ -1,0 +1,133 @@
+package inputhandlers
+
+import (
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/connections"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+// TestMain initializes shared infrastructure (logging) required by the
+// inputhandlers package before any tests in this package run.
+func TestMain(m *testing.M) {
+	mudlog.SetupLogger(nil, "", "", false)
+	m.Run()
+}
+
+// newTestUser creates a minimal UserRecord for use in auth tests.
+// The Character field is nil intentionally — auth checks only inspect Role.
+func newTestUser(userId int, connId connections.ConnectionId, role string) *users.UserRecord {
+	u := &users.UserRecord{
+		UserId:   userId,
+		Role:     role,
+		Username: "testuser",
+	}
+	return u
+}
+
+func TestTrySystemCommand_AuthorizationChecks(t *testing.T) {
+	const (
+		adminConnId    connections.ConnectionId = 1001
+		nonAdminConnId connections.ConnectionId = 1002
+		noUserConnId   connections.ConnectionId = 1003
+	)
+
+	setup := func() {
+		users.ResetActiveUsers()
+
+		adminUser := &users.UserRecord{
+			UserId:   1,
+			Role:     users.RoleAdmin,
+			Username: "admin",
+		}
+		nonAdminUser := &users.UserRecord{
+			UserId:   2,
+			Role:     users.RoleUser,
+			Username: "player",
+		}
+
+		users.SetTestUser(adminUser)
+		users.SetTestConnection(adminConnId, adminUser.UserId)
+
+		users.SetTestUser(nonAdminUser)
+		users.SetTestConnection(nonAdminConnId, nonAdminUser.UserId)
+		// noUserConnId intentionally has no user registered
+	}
+
+	tests := []struct {
+		name         string
+		cmd          string
+		connId       connections.ConnectionId
+		wantHandled  bool
+		description  string
+	}{
+		{
+			name:        "shutdown rejected for non-admin user",
+			cmd:         "/shutdown",
+			connId:      nonAdminConnId,
+			wantHandled: false,
+			description: "/shutdown must be rejected when the requesting user does not have the admin role",
+		},
+		{
+			name:        "reload rejected for non-admin user",
+			cmd:         "/reload",
+			connId:      nonAdminConnId,
+			wantHandled: false,
+			description: "/reload must be rejected when the requesting user does not have the admin role",
+		},
+		{
+			name:        "shutdown rejected for unknown connection (no user)",
+			cmd:         "/shutdown",
+			connId:      noUserConnId,
+			wantHandled: false,
+			description: "/shutdown must be rejected when no user record is associated with the connection",
+		},
+		{
+			name:        "reload rejected for unknown connection (no user)",
+			cmd:         "/reload",
+			connId:      noUserConnId,
+			wantHandled: false,
+			description: "/reload must be rejected when no user record is associated with the connection",
+		},
+		{
+			name:        "shutdown accepted for admin user",
+			cmd:         "/shutdown 0",
+			connId:      adminConnId,
+			wantHandled: true,
+			description: "/shutdown must be accepted (return true) when the requesting user has the admin role",
+		},
+		{
+			name:        "reload accepted for admin user",
+			cmd:         "/reload",
+			connId:      adminConnId,
+			wantHandled: true,
+			description: "/reload must be accepted (return true) when the requesting user has the admin role",
+		},
+		{
+			name:        "unknown system command returns false regardless of role",
+			cmd:         "/notacommand",
+			connId:      adminConnId,
+			wantHandled: false,
+			description: "an unrecognised system command must not be handled",
+		},
+		{
+			name:        "non-slash prefix returns false",
+			cmd:         "shutdown",
+			connId:      adminConnId,
+			wantHandled: false,
+			description: "input without the / prefix must not be treated as a system command",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			got := trySystemCommand(tt.cmd, tt.connId)
+			if got != tt.wantHandled {
+				t.Errorf("%s: trySystemCommand(%q, connId=%d) = %v, want %v",
+					tt.description, tt.cmd, tt.connId, got, tt.wantHandled)
+			}
+		})
+	}
+}

--- a/internal/users/testhelpers.go
+++ b/internal/users/testhelpers.go
@@ -1,5 +1,7 @@
 package users
 
+import "github.com/GoMudEngine/GoMud/internal/connections"
+
 // Test helpers for cross-package testing.
 // These functions allow other internal packages to set up user state
 // for testing without going through the full LoginUser flow.
@@ -15,6 +17,14 @@ func SetTestUser(u *UserRecord) {
 // For testing only.
 func RemoveTestUser(userId int) {
 	delete(userManager.Users, userId)
+}
+
+// SetTestConnection registers a connection-to-user mapping.
+// Must be called alongside SetTestUser so that GetByConnectionId resolves correctly.
+// For testing only.
+func SetTestConnection(connectionId connections.ConnectionId, userId int) {
+	userManager.Connections[connectionId] = userId
+	userManager.UserConnections[userId] = connectionId
 }
 
 // ResetActiveUsers resets the user manager to a clean state.


### PR DESCRIPTION
## Summary
Adds defense-in-depth authorization check inside trySystemCommand() for /shutdown and /reload. Previously auth was only enforced at handler registration time.

## Changes
- `systemcommands.go`: After command lookup, verifies user has admin role via `users.GetByConnectionId`. Non-admin or unknown connections are rejected with a warning log.
- `/quit` remains available to all users.
- Adds `SetTestConnection` helper to users/testhelpers.go for cross-package test setup.

## Test plan
- [x] 8 test cases: shutdown/reload rejected for non-admin, rejected for unknown connection, accepted for admin, unknown command and non-slash prefix handled correctly
- [x] Full test suite passes

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)