### PR TITLE
Add IP-based login rate limiting with progressive backoff

### DIFF
--- a/internal/inputhandlers/login.go
+++ b/internal/inputhandlers/login.go
@@ -4,6 +4,7 @@ import (
 	// ... other imports
 
 	"fmt"
+	"net"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/connections"
@@ -25,9 +26,19 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 
 		if userExists {
 
+			// Check rate limiting before attempting password verification.
+			connDetails := connections.Get(clientInput.ConnectionId)
+			ip := extractIP(connDetails)
+			if defaultRateLimiter.IsBlocked(ip) {
+				connections.SendTo([]byte("Too many failed attempts. Please try again later."), clientInput.ConnectionId)
+				connections.SendTo(term.CRLF, clientInput.ConnectionId)
+				connections.Remove(clientInput.ConnectionId)
+				return false
+			}
+
 			if results["kickuser"] == "y" {
 
-				connDetails := connections.Get(clientInput.ConnectionId)
+				connDetails = connections.Get(clientInput.ConnectionId)
 
 				// Disconnect/kick the user currently connected
 				userid := users.FindUserId(results["username"])
@@ -55,6 +66,7 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 			}
 
 			if !tmpUser.PasswordMatches(password) {
+				defaultRateLimiter.RecordFailure(ip)
 				connections.SendTo([]byte(`Nope. Bye!`), clientInput.ConnectionId)
 				connections.SendTo(term.CRLF, clientInput.ConnectionId)
 				connections.Remove(clientInput.ConnectionId)
@@ -69,6 +81,7 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 				return false // Indicate failure, connection removed
 			}
 
+			defaultRateLimiter.RecordSuccess(ip)
 			sharedState["UserObject"] = loggedInUser // For main loop
 
 			if len(msg) > 0 {
@@ -147,6 +160,24 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 
 		return true // Indicate success, handler can be removed
 	}
+}
+
+// extractIP pulls the remote IP address out of a ConnectionDetails, stripping
+// the port so the rate limiter can key on IP alone.
+func extractIP(cd *connections.ConnectionDetails) string {
+	if cd == nil {
+		return ""
+	}
+	addr := cd.RemoteAddr()
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		// addr.String() may already be a bare IP (e.g. from a Unix socket fallback).
+		return addr.String()
+	}
+	return host
 }
 
 func GetLoginPromptHandler() connections.InputHandler {

--- a/internal/inputhandlers/ratelimiter.go
+++ b/internal/inputhandlers/ratelimiter.go
@@ -1,0 +1,126 @@
+package inputhandlers
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+type attemptInfo struct {
+	failures     int
+	lastFailure  time.Time
+	blockedUntil time.Time
+}
+
+// LoginRateLimiter tracks failed login attempts per IP and enforces progressive
+// backoff to defend against brute-force credential stuffing.
+type LoginRateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string]*attemptInfo
+	disabled bool // for testing
+}
+
+var defaultRateLimiter = NewLoginRateLimiter()
+
+// NewLoginRateLimiter creates a ready-to-use LoginRateLimiter.
+func NewLoginRateLimiter() *LoginRateLimiter {
+	return &LoginRateLimiter{
+		attempts: make(map[string]*attemptInfo),
+	}
+}
+
+// IsBlocked returns true if the IP is currently rate-limited.
+// Localhost (127.0.0.1 and ::1) is never blocked — admin backdoor.
+func (l *LoginRateLimiter) IsBlocked(ip string) bool {
+	if l.disabled {
+		return false
+	}
+	if isLocalhost(ip) {
+		return false
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	info, ok := l.attempts[ip]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(info.blockedUntil)
+}
+
+// RecordFailure records a failed login attempt for the given IP and sets
+// progressive backoff: 2 s after 3 failures, 10 s after 5, 30 s after 10+.
+func (l *LoginRateLimiter) RecordFailure(ip string) {
+	if isLocalhost(ip) {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	info, ok := l.attempts[ip]
+	if !ok {
+		info = &attemptInfo{}
+		l.attempts[ip] = info
+	}
+
+	info.failures++
+	info.lastFailure = time.Now()
+
+	var blockDuration time.Duration
+	switch {
+	case info.failures >= 10:
+		blockDuration = 30 * time.Second
+	case info.failures >= 5:
+		blockDuration = 10 * time.Second
+	case info.failures >= 3:
+		blockDuration = 2 * time.Second
+	}
+
+	if blockDuration > 0 {
+		info.blockedUntil = time.Now().Add(blockDuration)
+	}
+}
+
+// RecordSuccess clears the failure record for the given IP.
+func (l *LoginRateLimiter) RecordSuccess(ip string) {
+	if isLocalhost(ip) {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.attempts, ip)
+}
+
+// Reset clears all state. Intended for testing.
+func (l *LoginRateLimiter) Reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.attempts = make(map[string]*attemptInfo)
+}
+
+// SetDisabled disables or enables rate limiting. Intended for testing.
+func (l *LoginRateLimiter) SetDisabled(v bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.disabled = v
+}
+
+// isLocalhost returns true for loopback addresses (127.0.0.1 and ::1).
+// These are never subject to rate limiting as an admin backdoor.
+func isLocalhost(ip string) bool {
+	// Fast path for the two canonical loopback strings.
+	if ip == "127.0.0.1" || ip == "::1" {
+		return true
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback()
+}

--- a/internal/inputhandlers/ratelimiter_test.go
+++ b/internal/inputhandlers/ratelimiter_test.go
@@ -1,0 +1,282 @@
+package inputhandlers
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestLimiter returns a fresh limiter for each test to ensure isolation.
+func newTestLimiter() *LoginRateLimiter {
+	return NewLoginRateLimiter()
+}
+
+func TestRateLimiter_NewLimiterHasNoBlocks(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+	if l.IsBlocked("1.2.3.4") {
+		t.Error("new limiter should not block any IP")
+	}
+}
+
+func TestRateLimiter_SingleFailureDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+	l.RecordFailure("1.2.3.4")
+	if l.IsBlocked("1.2.3.4") {
+		t.Error("single failure should not block")
+	}
+}
+
+func TestRateLimiter_TwoFailuresDoNotBlock(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+	l.RecordFailure("1.2.3.4")
+	l.RecordFailure("1.2.3.4")
+	if l.IsBlocked("1.2.3.4") {
+		t.Error("two failures should not block")
+	}
+}
+
+func TestRateLimiter_ThreeFailuresBlockFor2s(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 3; i++ {
+		l.RecordFailure("1.2.3.4")
+	}
+
+	if !l.IsBlocked("1.2.3.4") {
+		t.Error("3 failures should block")
+	}
+
+	// Verify the block duration is ~2 seconds by inspecting internal state.
+	l.mu.Lock()
+	info := l.attempts["1.2.3.4"]
+	remaining := time.Until(info.blockedUntil)
+	l.mu.Unlock()
+
+	if remaining <= 0 || remaining > 2*time.Second+100*time.Millisecond {
+		t.Errorf("expected ~2s block, got remaining=%v", remaining)
+	}
+
+	// Simulate time passing: set blockedUntil to the past.
+	l.mu.Lock()
+	l.attempts["1.2.3.4"].blockedUntil = time.Now().Add(-1 * time.Second)
+	l.mu.Unlock()
+
+	if l.IsBlocked("1.2.3.4") {
+		t.Error("block should have expired after advancing time")
+	}
+}
+
+func TestRateLimiter_FiveFailuresBlockFor10s(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 5; i++ {
+		l.RecordFailure("10.0.0.1")
+	}
+
+	if !l.IsBlocked("10.0.0.1") {
+		t.Error("5 failures should block")
+	}
+
+	l.mu.Lock()
+	info := l.attempts["10.0.0.1"]
+	remaining := time.Until(info.blockedUntil)
+	l.mu.Unlock()
+
+	if remaining <= 0 || remaining > 10*time.Second+100*time.Millisecond {
+		t.Errorf("expected ~10s block, got remaining=%v", remaining)
+	}
+
+	// Simulate time passing.
+	l.mu.Lock()
+	l.attempts["10.0.0.1"].blockedUntil = time.Now().Add(-1 * time.Second)
+	l.mu.Unlock()
+
+	if l.IsBlocked("10.0.0.1") {
+		t.Error("block should have expired after advancing time")
+	}
+}
+
+func TestRateLimiter_TenFailuresBlockFor30s(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 10; i++ {
+		l.RecordFailure("192.168.1.1")
+	}
+
+	if !l.IsBlocked("192.168.1.1") {
+		t.Error("10 failures should block")
+	}
+
+	l.mu.Lock()
+	info := l.attempts["192.168.1.1"]
+	remaining := time.Until(info.blockedUntil)
+	l.mu.Unlock()
+
+	if remaining <= 0 || remaining > 30*time.Second+100*time.Millisecond {
+		t.Errorf("expected ~30s block, got remaining=%v", remaining)
+	}
+
+	// Simulate time passing.
+	l.mu.Lock()
+	l.attempts["192.168.1.1"].blockedUntil = time.Now().Add(-1 * time.Second)
+	l.mu.Unlock()
+
+	if l.IsBlocked("192.168.1.1") {
+		t.Error("block should have expired after advancing time")
+	}
+}
+
+func TestRateLimiter_SuccessfulLoginClearsFailures(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 5; i++ {
+		l.RecordFailure("2.3.4.5")
+	}
+	if !l.IsBlocked("2.3.4.5") {
+		t.Fatal("should be blocked before success")
+	}
+
+	l.RecordSuccess("2.3.4.5")
+
+	if l.IsBlocked("2.3.4.5") {
+		t.Error("successful login should clear block")
+	}
+
+	// Entry should be fully removed, not just unblocked.
+	l.mu.Lock()
+	_, exists := l.attempts["2.3.4.5"]
+	l.mu.Unlock()
+	if exists {
+		t.Error("RecordSuccess should delete the attempts entry")
+	}
+}
+
+func TestRateLimiter_LocalhostIPv4NeverBlocked(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 20; i++ {
+		l.RecordFailure("127.0.0.1")
+	}
+	if l.IsBlocked("127.0.0.1") {
+		t.Error("127.0.0.1 should never be blocked")
+	}
+}
+
+func TestRateLimiter_LocalhostIPv6NeverBlocked(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 20; i++ {
+		l.RecordFailure("::1")
+	}
+	if l.IsBlocked("::1") {
+		t.Error("::1 should never be blocked")
+	}
+}
+
+func TestRateLimiter_Reset(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	for i := 0; i < 10; i++ {
+		l.RecordFailure("3.4.5.6")
+	}
+	if !l.IsBlocked("3.4.5.6") {
+		t.Fatal("should be blocked before reset")
+	}
+
+	l.Reset()
+
+	if l.IsBlocked("3.4.5.6") {
+		t.Error("Reset should clear all blocks")
+	}
+
+	l.mu.Lock()
+	count := len(l.attempts)
+	l.mu.Unlock()
+	if count != 0 {
+		t.Errorf("Reset should empty attempts map, got %d entries", count)
+	}
+}
+
+func TestRateLimiter_SetDisabledPreventsBlocking(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+	l.SetDisabled(true)
+
+	for i := 0; i < 10; i++ {
+		l.RecordFailure("4.5.6.7")
+	}
+	if l.IsBlocked("4.5.6.7") {
+		t.Error("disabled limiter should never block")
+	}
+
+	// Re-enable and verify the underlying state is present.
+	l.SetDisabled(false)
+	if !l.IsBlocked("4.5.6.7") {
+		t.Error("after re-enabling, recorded failures should still block")
+	}
+}
+
+func TestRateLimiter_DifferentIPsTrackedIndependently(t *testing.T) {
+	t.Parallel()
+	l := newTestLimiter()
+
+	// Block ip1 with 5 failures.
+	for i := 0; i < 5; i++ {
+		l.RecordFailure("5.6.7.8")
+	}
+
+	// ip2 has only 1 failure — should not be blocked.
+	l.RecordFailure("9.8.7.6")
+
+	if !l.IsBlocked("5.6.7.8") {
+		t.Error("5.6.7.8 should be blocked")
+	}
+	if l.IsBlocked("9.8.7.6") {
+		t.Error("9.8.7.6 should not be blocked")
+	}
+
+	// Clearing ip1 should not affect ip2.
+	l.RecordSuccess("5.6.7.8")
+	if l.IsBlocked("5.6.7.8") {
+		t.Error("5.6.7.8 should be unblocked after success")
+	}
+	if l.IsBlocked("9.8.7.6") {
+		t.Error("9.8.7.6 should still not be blocked")
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"IPv4 loopback", "127.0.0.1", true},
+		{"IPv6 loopback", "::1", true},
+		{"IPv4 loopback non-standard", "127.0.0.2", true},
+		{"public IPv4", "8.8.8.8", false},
+		{"private RFC1918", "192.168.1.1", false},
+		{"empty string", "", false},
+		{"garbage", "not-an-ip", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isLocalhost(tt.ip)
+			if got != tt.want {
+				t.Errorf("isLocalhost(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,7 +1,9 @@
 package web
 
 import (
+	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
@@ -12,6 +14,89 @@ var (
 	authCache = map[string]time.Time{}
 )
 
+// webAuthLimiter is a simple IP-based rate limiter for the admin web panel.
+// Progressive backoff: 3 failures = 2 s, 5 = 10 s, 10+ = 30 s.
+// Localhost (127.0.0.1, ::1) is never blocked.
+var webAuthLimiter = &webRateLimiter{attempts: make(map[string]*webAttemptInfo)}
+
+type webAttemptInfo struct {
+	failures     int
+	blockedUntil time.Time
+}
+
+type webRateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string]*webAttemptInfo
+}
+
+func (wl *webRateLimiter) isBlocked(ip string) bool {
+	if isWebLocalhost(ip) {
+		return false
+	}
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	info, ok := wl.attempts[ip]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(info.blockedUntil)
+}
+
+func (wl *webRateLimiter) recordFailure(ip string) {
+	if isWebLocalhost(ip) {
+		return
+	}
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	info, ok := wl.attempts[ip]
+	if !ok {
+		info = &webAttemptInfo{}
+		wl.attempts[ip] = info
+	}
+	info.failures++
+	var d time.Duration
+	switch {
+	case info.failures >= 10:
+		d = 30 * time.Second
+	case info.failures >= 5:
+		d = 10 * time.Second
+	case info.failures >= 3:
+		d = 2 * time.Second
+	}
+	if d > 0 {
+		info.blockedUntil = time.Now().Add(d)
+	}
+}
+
+func (wl *webRateLimiter) recordSuccess(ip string) {
+	if isWebLocalhost(ip) {
+		return
+	}
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	delete(wl.attempts, ip)
+}
+
+func isWebLocalhost(ip string) bool {
+	if ip == "127.0.0.1" || ip == "::1" {
+		return true
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback()
+}
+
+// remoteIP extracts the IP address from an HTTP request's RemoteAddr.
+func remoteIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
 func handlerToHandlerFunc(h http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		h.ServeHTTP(w, r)
@@ -20,6 +105,16 @@ func handlerToHandlerFunc(h http.Handler) http.HandlerFunc {
 
 func doBasicAuth(next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		ip := remoteIP(r)
+
+		// Reject rate-limited IPs before doing any credential work.
+		if webAuthLimiter.isBlocked(ip) {
+			mudlog.Warn("ADMIN LOGIN BLOCKED", "ip", ip, "reason", "rate limited")
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+			http.Error(w, "Too many failed attempts. Please try again later.", http.StatusTooManyRequests)
+			return
+		}
 
 		authHeader := r.Header.Get("Authorization")
 
@@ -50,6 +145,8 @@ func doBasicAuth(next http.HandlerFunc) http.HandlerFunc {
 
 						mudlog.Warn("ADMIN LOGIN", "username", username, "success", true)
 
+						webAuthLimiter.recordSuccess(ip)
+
 						// Cache auth for 30 minutes to avoid re-auth every load
 						authCache[authHeader] = time.Now().Add(time.Minute * 30)
 
@@ -67,6 +164,9 @@ func doBasicAuth(next http.HandlerFunc) http.HandlerFunc {
 				mudlog.Error("ADMIN LOGIN", "username", username, "success", false, "error", err)
 			}
 		}
+
+		// Record the failed attempt before responding.
+		webAuthLimiter.recordFailure(ip)
 
 		// If the Authentication header is not present, is invalid, or the
 		// username or password is wrong, then set a WWW-Authenticate


### PR DESCRIPTION
## Summary
- IP-based rate limiting for telnet login and web admin panel
- Progressive backoff: 2s after 3 failures, 10s after 5, 30s after 10+
- Localhost never blocked (admin backdoor via port 9999)
- Testing support: Reset() and SetDisabled() methods

## Changes
- New `ratelimiter.go` — LoginRateLimiter with mutex-protected IP tracking
- `login.go` — rate limit check before password attempt, record failure/success
- `auth.go` — self-contained web rate limiter, HTTP 429 for blocked IPs

## Test plan
- [x] 13 tests covering: progressive thresholds, localhost exemption, success clearing, reset, disable, independent IP tracking
- [x] All tests parallel with deterministic timing (no time.Sleep)
- [x] Full test suite passes

Partial fix for #3 — basic rate limiting. MFA remains future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)