### PR TITLE
Add 5-second write deadline to prevent stalled clients blocking server

### DIFF
--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -20,6 +20,12 @@ const (
 	LoggedIn
 	Zombie
 	MaxHistory = 10
+
+	// writeDeadline is the maximum time allowed for a single Write call.
+	// If a client's TCP receive buffer fills up and the write blocks beyond
+	// this duration, the write will fail and the connection can be dropped
+	// rather than stalling the entire server.
+	writeDeadline = 5 * time.Second
 )
 
 type InputHistory struct {
@@ -234,14 +240,25 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 			return 0, nil
 		}
 
-		err := cd.wsConn.WriteMessage(websocket.TextMessage, p)
-		if err != nil {
+		if err := cd.wsConn.SetWriteDeadline(time.Now().Add(writeDeadline)); err != nil {
 			return 0, err
+		}
+		writeErr := cd.wsConn.WriteMessage(websocket.TextMessage, p)
+		// Reset to no deadline regardless of outcome.
+		_ = cd.wsConn.SetWriteDeadline(time.Time{})
+		if writeErr != nil {
+			return 0, writeErr
 		}
 		return len(p), nil
 	}
 
-	return cd.conn.Write(p)
+	if err := cd.conn.SetWriteDeadline(time.Now().Add(writeDeadline)); err != nil {
+		return 0, err
+	}
+	n, err = cd.conn.Write(p)
+	// Reset to no deadline regardless of outcome.
+	_ = cd.conn.SetWriteDeadline(time.Time{})
+	return n, err
 }
 
 func (cd *ConnectionDetails) Read(p []byte) (n int, err error) {

--- a/internal/connections/connections_test.go
+++ b/internal/connections/connections_test.go
@@ -1,0 +1,102 @@
+package connections
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestWrite_EmptyPayload verifies that the early return for zero-length writes
+// actually fires. We use a closed connection so that if the early return is
+// bypassed and Write falls through to conn.Write, it will error.
+func TestWrite_EmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+	server.Close()
+	client.Close()
+
+	cd := &ConnectionDetails{conn: client}
+
+	n, err := cd.Write([]byte{})
+	if err != nil {
+		t.Errorf("Write(empty) should return early without touching conn, but got error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Write(empty) returned n=%d, want 0", n)
+	}
+}
+
+// TestWrite_CompletesNormally verifies that a write succeeds when the other
+// end of the connection is actively reading.
+func TestWrite_CompletesNormally(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	// Drain the server side so writes can complete.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := server.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	cd := &ConnectionDetails{conn: client}
+
+	payload := []byte("hello world")
+	n, err := cd.Write(payload)
+	if err != nil {
+		t.Fatalf("Write returned unexpected error: %v", err)
+	}
+	// Note: Write replaces \n with \r\n; since there are none here the length
+	// is unchanged.
+	if n != len(payload) {
+		t.Errorf("Write returned n=%d, want %d", n, len(payload))
+	}
+}
+
+// TestWrite_TelnetStalledClient verifies that Write returns an error (deadline
+// exceeded) within a bounded time when the remote end of a telnet connection
+// stops reading and the pipe buffer fills up.  Without the write deadline this
+// call would block forever, stalling the entire server.
+func TestWrite_TelnetStalledClient(t *testing.T) {
+	// Not marked t.Parallel() — this test intentionally lets the deadline fire
+	// (~5 s) and we do not want it to count against other parallel tests'
+	// wallclock budget unexpectedly.  It has its own 15 s hard limit.
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	cd := &ConnectionDetails{conn: client}
+
+	// Do NOT read from server — writes will fill the pipe buffer and block.
+
+	done := make(chan error, 1)
+	go func() {
+		data := make([]byte, 4096)
+		for i := 0; i < 1000; i++ {
+			if _, err := cd.Write(data); err != nil {
+				done <- err
+				return
+			}
+		}
+		// All 1000 writes succeeded without error — deadline had no effect.
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected Write to fail on stalled client (deadline exceeded), but all writes succeeded")
+		}
+		// Received a deadline/timeout error — correct behaviour.
+	case <-time.After(15 * time.Second):
+		t.Fatal("Write blocked for more than 15 s — write deadline is not working")
+	}
+}


### PR DESCRIPTION
## Summary
Adds write deadlines to telnet and WebSocket connections to prevent a stalled client from blocking the entire game loop.

## Changes
- `connectiondetails.go`: SetWriteDeadline(5s) before every Write(), reset to zero after. Both telnet and WebSocket paths.
- SendTo already removes connections on write errors, so stalled clients get disconnected automatically.

## Test plan
- [x] TestWrite_EmptyPayload — validates early return using closed-pipe tripwire (fails if early return removed)
- [x] TestWrite_CompletesNormally — happy path, correct byte count
- [x] TestWrite_TelnetStalledClient — zero-buffered pipe with no reader, verifies deadline fires within 5s instead of blocking forever
- [x] Full test suite passes

Partial fix for #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)