### PR TITLE
Add RWMutex to ActiveUsers to eliminate data races

### DIFF
--- a/internal/users/race_test.go
+++ b/internal/users/race_test.go
@@ -1,0 +1,82 @@
+package users
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/connections"
+)
+
+// TestUserManager_ConcurrentAccess exercises concurrent reads and writes on
+// userManager's maps.  Run with -race; the test should FAIL (data race) before
+// the sync.RWMutex fix is applied and PASS afterwards.
+func TestUserManager_ConcurrentAccess(t *testing.T) {
+	ResetActiveUsers()
+
+	const goroutines = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 3)
+
+	// Writers: add users via SetTestUser
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			connId := connections.ConnectionId(i + 1)
+			u := &UserRecord{
+				UserId:       i + 1,
+				Username:     "user" + string(rune('A'+i)),
+				connectionId: connId,
+			}
+			SetTestUser(u)
+			SetTestConnection(connId, u.UserId)
+		}()
+	}
+
+	// Readers: look up users by id
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			_ = GetByUserId(i + 1)
+		}()
+	}
+
+	// Mixed: iterate all active users
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_ = GetAllActiveUsers()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestUserManager_ConcurrentLogout exercises concurrent LogOutUserByConnectionId
+// calls against the maps.
+func TestUserManager_ConcurrentLogout(t *testing.T) {
+	ResetActiveUsers()
+
+	const count = 10
+
+	// Pre-populate: only set the Connections map entry (no UserRecord) to
+	// exercise the nil-user branch without triggering SaveUser disk I/O.
+	for i := 1; i <= count; i++ {
+		connId := connections.ConnectionId(i)
+		userManager.Connections[connId] = i // orphan connection
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for i := 1; i <= count; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			connId := connections.ConnectionId(i)
+			_ = LogOutUserByConnectionId(connId)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/users/testhelpers.go
+++ b/internal/users/testhelpers.go
@@ -10,12 +10,16 @@ import "github.com/GoMudEngine/GoMud/internal/connections"
 // SetTestUser adds a user directly to the active users map.
 // For testing only.
 func SetTestUser(u *UserRecord) {
+	userManager.mu.Lock()
+	defer userManager.mu.Unlock()
 	userManager.Users[u.UserId] = u
 }
 
 // RemoveTestUser removes a user from the active users map.
 // For testing only.
 func RemoveTestUser(userId int) {
+	userManager.mu.Lock()
+	defer userManager.mu.Unlock()
 	delete(userManager.Users, userId)
 }
 
@@ -23,6 +27,8 @@ func RemoveTestUser(userId int) {
 // Must be called alongside SetTestUser so that GetByConnectionId resolves correctly.
 // For testing only.
 func SetTestConnection(connectionId connections.ConnectionId, userId int) {
+	userManager.mu.Lock()
+	defer userManager.mu.Unlock()
 	userManager.Connections[connectionId] = userId
 	userManager.UserConnections[userId] = connectionId
 }

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoMudEngine/GoMud/internal/characters"
@@ -26,6 +27,7 @@ var (
 )
 
 type ActiveUsers struct {
+	mu                sync.RWMutex                        // guards all maps below
 	Users             map[int]*UserRecord                 // userId to UserRecord
 	Usernames         map[string]int                      // username to userId
 	Connections       map[connections.ConnectionId]int    // connectionId to userId
@@ -44,6 +46,8 @@ func newUserManager() *ActiveUsers {
 }
 
 func RemoveZombieUser(userId int) {
+	userManager.mu.Lock()
+	defer userManager.mu.Unlock()
 
 	if u := userManager.Users[userId]; u != nil {
 		u.Character.SetAdjective(`zombie`, false)
@@ -54,17 +58,23 @@ func RemoveZombieUser(userId int) {
 }
 
 func IsZombieConnection(connectionId connections.ConnectionId) bool {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 	_, ok := userManager.ZombieConnections[connectionId]
 	return ok
 }
 
 func RemoveZombieConnection(connectionId connections.ConnectionId) {
+	userManager.mu.Lock()
+	defer userManager.mu.Unlock()
 	delete(userManager.ZombieConnections, connectionId)
 }
 
 // Returns a slice of userId's
 // These userId's are zombies that have reached expiration
 func GetExpiredZombies(expirationTurn uint64) []int {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 
 	expiredUsers := make([]int, 0)
 
@@ -78,6 +88,8 @@ func GetExpiredZombies(expirationTurn uint64) []int {
 }
 
 func GetConnectionId(userId int) connections.ConnectionId {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 	if user, ok := userManager.Users[userId]; ok {
 		return user.connectionId
 	}
@@ -85,6 +97,8 @@ func GetConnectionId(userId int) connections.ConnectionId {
 }
 
 func GetConnectionIds(userIds []int) []connections.ConnectionId {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 
 	connectionIds := make([]connections.ConnectionId, 0, len(userIds))
 	for _, userId := range userIds {
@@ -97,6 +111,9 @@ func GetConnectionIds(userIds []int) []connections.ConnectionId {
 }
 
 func GetAllActiveUsers() []*UserRecord {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
+
 	ret := []*UserRecord{}
 
 	for _, userPtr := range userManager.Users {
@@ -109,6 +126,8 @@ func GetAllActiveUsers() []*UserRecord {
 }
 
 func GetOnlineUserIds() []int {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 
 	onlineList := make([]int, 0, len(userManager.Users))
 	for _, user := range userManager.Users {
@@ -118,6 +137,8 @@ func GetOnlineUserIds() []int {
 }
 
 func GetByCharacterName(name string) *UserRecord {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 
 	var closeMatch *UserRecord = nil
 
@@ -136,6 +157,8 @@ func GetByCharacterName(name string) *UserRecord {
 }
 
 func GetByUserId(userId int) *UserRecord {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 
 	if user, ok := userManager.Users[userId]; ok {
 		return user
@@ -145,6 +168,8 @@ func GetByUserId(userId int) *UserRecord {
 }
 
 func GetByConnectionId(connectionId connections.ConnectionId) *UserRecord {
+	userManager.mu.RLock()
+	defer userManager.mu.RUnlock()
 
 	if userId, ok := userManager.Connections[connectionId]; ok {
 		return userManager.Users[userId]
@@ -160,6 +185,8 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 
 	user.Character.SetAdjective(`zombie`, false)
 
+	userManager.mu.Lock()
+
 	// If they're already logged in
 	if userId, ok := userManager.Usernames[user.Username]; ok {
 
@@ -167,7 +194,7 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 		if otherConnId, ok := userManager.UserConnections[userId]; ok {
 
 			// Is it a zombie connection? If so, lets make this new connection the owner
-			if IsZombieConnection(otherConnId) {
+			if _, isZombie := userManager.ZombieConnections[otherConnId]; isZombie {
 
 				mudlog.Info("LoginUser()", "Zombie", true)
 
@@ -175,7 +202,8 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 					user = zombieUser
 				}
 
-				RemoveZombieConnection(otherConnId)
+				// inline RemoveZombieConnection — already holding mu
+				delete(userManager.ZombieConnections, otherConnId)
 
 				user.connectionId = connectionId
 
@@ -183,6 +211,8 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 				userManager.Usernames[user.Username] = user.UserId
 				userManager.Connections[user.connectionId] = user.UserId
 				userManager.UserConnections[user.UserId] = user.connectionId
+
+				userManager.mu.Unlock()
 
 				for _, mobInstId := range user.Character.GetCharmIds() {
 					if !mobs.MobInstanceExists(mobInstId) {
@@ -200,6 +230,7 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 
 		}
 
+		userManager.mu.Unlock()
 		// Otherwise, someone else is logged in, can't double-login!
 		return nil, "That user is already logged in.", errors.New("user is already logged in")
 	}
@@ -216,6 +247,8 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 	userManager.Connections[user.connectionId] = user.UserId
 	userManager.UserConnections[user.UserId] = user.connectionId
 
+	userManager.mu.Unlock()
+
 	mudlog.Info("LOGIN", "userId", user.UserId)
 
 	user.EventLog.Add(`conn`, `Connected`)
@@ -230,6 +263,8 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 }
 
 func SetZombieUser(userId int) {
+	userManager.mu.Lock()
+	defer userManager.mu.Unlock()
 
 	if u, ok := userManager.Users[userId]; ok {
 
@@ -255,9 +290,16 @@ func SetZombieUser(userId int) {
 }
 
 func SaveAllUsers(isAutoSave ...bool) {
-
+	// Snapshot user records under read lock so we don't hold mu across disk I/O.
+	userManager.mu.RLock()
+	snapshot := make([]UserRecord, 0, len(userManager.Users))
 	for _, u := range userManager.Users {
-		if err := SaveUser(*u, isAutoSave...); err != nil {
+		snapshot = append(snapshot, *u)
+	}
+	userManager.mu.RUnlock()
+
+	for _, u := range snapshot {
+		if err := SaveUser(u, isAutoSave...); err != nil {
 			mudlog.Error("SaveAllUsers()", "error", err.Error())
 		}
 	}
@@ -266,27 +308,35 @@ func SaveAllUsers(isAutoSave ...bool) {
 
 func LogOutUserByConnectionId(connectionId connections.ConnectionId) error {
 
-	u := GetByConnectionId(connectionId)
+	userManager.mu.Lock()
 
-	if _, ok := userManager.Connections[connectionId]; ok {
-
-		// Make sure the user data is saved to a file.
-		if u != nil {
-			u.Character.Validate()
-			SaveUser(*u)
-
-			delete(userManager.Users, u.UserId)
-			delete(userManager.Usernames, u.Username)
-			delete(userManager.Connections, u.connectionId)
-			delete(userManager.UserConnections, u.UserId)
-		} else {
-			// Connection exists but user record is missing — clean up the connection entry
-			delete(userManager.Connections, connectionId)
-		}
-
-		return nil
+	userId, connExists := userManager.Connections[connectionId]
+	if !connExists {
+		userManager.mu.Unlock()
+		return errors.New("user not found for connection")
 	}
-	return errors.New("user not found for connection")
+
+	u := userManager.Users[userId]
+
+	if u != nil {
+		// Snapshot before releasing lock so we can do I/O outside critical section.
+		uCopy := *u
+		delete(userManager.Users, u.UserId)
+		delete(userManager.Usernames, u.Username)
+		delete(userManager.Connections, u.connectionId)
+		delete(userManager.UserConnections, u.UserId)
+		userManager.mu.Unlock()
+
+		// Make sure the user data is saved to a file (I/O outside lock).
+		uCopy.Character.Validate()
+		SaveUser(uCopy)
+	} else {
+		// Connection exists but user record is missing — clean up the connection entry.
+		delete(userManager.Connections, connectionId)
+		userManager.mu.Unlock()
+	}
+
+	return nil
 }
 
 // First time creating a user.
@@ -296,20 +346,24 @@ func CreateUser(u *UserRecord) error {
 		return errors.New("that username is not allowed: " + err.Error())
 	}
 
+	// GetUniqueUserId calls GetAllActiveUsers which acquires RLock — call before Lock.
 	u.UserId = GetUniqueUserId()
 	u.Role = RoleUser
 
 	idx := NewUserIndex()
 	idx.AddUser(u.UserId, u.Username)
 
+	// SaveUser is disk I/O — do it before acquiring mu.
 	if err := SaveUser(*u); err != nil {
 		return err
 	}
 
+	userManager.mu.Lock()
 	userManager.Users[u.UserId] = u
 	userManager.Usernames[u.Username] = u.UserId
 	userManager.Connections[u.connectionId] = u.UserId
 	userManager.UserConnections[u.UserId] = u.connectionId
+	userManager.mu.Unlock()
 
 	return nil
 }
@@ -387,7 +441,10 @@ func SearchOfflineUsers(searchFunc func(u *UserRecord) bool) {
 			}
 
 			// If this is an online user, skip it
-			if _, ok := userManager.Usernames[uRecord.Username]; ok {
+			userManager.mu.RLock()
+			_, isOnline := userManager.Usernames[uRecord.Username]
+			userManager.mu.RUnlock()
+			if isOnline {
 				return nil
 			}
 


### PR DESCRIPTION
## Summary
Adds a sync.RWMutex to ActiveUsers to eliminate data races on the userManager singleton. Connection goroutines (LoginUser, CreateUser) were racing with the game loop on the Users/Usernames/Connections maps.

## Changes
- `users.go`: sync.RWMutex added to ActiveUsers, ~25 functions wrapped with appropriate lock
- Write lock: LoginUser, CreateUser, LogOutUserByConnectionId, SetZombieUser, RemoveZombieUser, RemoveZombieConnection
- Read lock: all Get* accessors, SaveAllUsers, SearchOfflineUsers
- `testhelpers.go`: test helpers also lock for safe concurrent test setup
- `race_test.go`: new concurrent tests that fail without the fix under -race

## Lock Ordering
- ActiveUsers.mu is always **below** mudLock — never acquired while holding mudLock
- Never held across file I/O (SaveUser) to prevent stalling the game loop on disk writes
- No deadlock risk

## Test plan
- [x] New concurrent tests fail with DATA RACE output without the fix
- [x] Same tests pass under -race after the fix
- [x] 21 users package tests all pass with -race
- [x] Full test suite passes with -race

Partial fix for #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)