### PR TITLE
Route GetAutoComplete through MainWorker via request/reply channel

### DIFF
--- a/world.go
+++ b/world.go
@@ -39,6 +39,12 @@ func (wi WorldInput) Id() int {
 	return wi.FromId
 }
 
+type autoCompleteRequest struct {
+	userId int
+	input  string
+	reply  chan []string // buffered(1) so worker never blocks
+}
+
 type World struct {
 	worldInput         chan WorldInput
 	ignoreInput        map[int]uint64 // userid->turn set to ignore
@@ -46,6 +52,7 @@ type World struct {
 	leaveWorldUserId   chan int
 	logoutConnectionId chan connections.ConnectionId
 	zombieFlag         chan [2]int
+	autoCompleteReq    chan autoCompleteRequest
 	//
 	eventRequeue          []events.Event
 	userInputEventTracker map[int]struct{}
@@ -61,6 +68,7 @@ func NewWorld(osSignalChan chan os.Signal) *World {
 		leaveWorldUserId:   make(chan int),
 		logoutConnectionId: make(chan connections.ConnectionId),
 		zombieFlag:         make(chan [2]int),
+		autoCompleteReq:    make(chan autoCompleteRequest),
 		//
 		eventRequeue:          []events.Event{},
 		userInputEventTracker: map[int]struct{}{},
@@ -299,7 +307,7 @@ Connected		+ InWorld  (non-zombie) 	No record in users.ZombieConnections								
 Disconnected	+ InWorld  (zombie)			Has record in users.ZombieConnections 								| has zombie flag		| user object in room
 */
 
-func (w *World) GetAutoComplete(userId int, inputText string) []string {
+func (w *World) doGetAutoComplete(userId int, inputText string) []string {
 
 	suggestions := []string{}
 
@@ -701,6 +709,30 @@ func (w *World) GetAutoComplete(userId int, inputText string) []string {
 	return suggestions
 }
 
+// GetAutoComplete is safe to call from any goroutine.
+// It sends a request to MainWorker, which runs the actual lookup
+// under the game lock and returns the result.
+func (w *World) GetAutoComplete(userId int, inputText string) []string {
+	reply := make(chan []string, 1)
+	req := autoCompleteRequest{
+		userId: userId,
+		input:  inputText,
+		reply:  reply,
+	}
+	select {
+	case w.autoCompleteReq <- req:
+		// sent; wait for reply
+	case <-time.After(500 * time.Millisecond):
+		return nil
+	}
+	select {
+	case result := <-reply:
+		return result
+	case <-time.After(500 * time.Millisecond):
+		return nil
+	}
+}
+
 const (
 	// Used in GameTickWorker()
 	// Used in MaintenanceWorker()
@@ -842,6 +874,20 @@ loop:
 				util.UnlockMud()
 
 			}
+
+		case req := <-w.autoCompleteReq:
+
+			util.LockMud()
+			result := w.doGetAutoComplete(req.userId, req.input)
+			util.UnlockMud()
+
+			// Non-blocking send to buffered reply channel.
+			// If the caller already timed out, drop the result.
+			select {
+			case req.reply <- result:
+			default:
+			}
+
 		}
 		c = configs.GetConfig()
 	}

--- a/world_autocomplete_test.go
+++ b/world_autocomplete_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestWorld builds a World with only the fields needed by GetAutoComplete
+// and the autoCompleteReq channel. The caller is responsible for servicing
+// (or not servicing) the channel.
+func newTestWorld() *World {
+	return &World{
+		autoCompleteReq: make(chan autoCompleteRequest),
+	}
+}
+
+// serviceOnce reads exactly one request from w.autoCompleteReq and replies
+// with fixedResult. It blocks until a request arrives or ctx is cancelled.
+func serviceOnce(w *World, fixedResult []string, done <-chan struct{}) {
+	select {
+	case req := <-w.autoCompleteReq:
+		select {
+		case req.reply <- fixedResult:
+		default:
+		}
+	case <-done:
+	}
+}
+
+// TestGetAutoComplete_ReplyReceived verifies that when MainWorker services the
+// request, GetAutoComplete returns the reply.
+func TestGetAutoComplete_ReplyReceived(t *testing.T) {
+	t.Parallel()
+
+	w := newTestWorld()
+	want := []string{"attack", "appraise"}
+	done := make(chan struct{})
+	defer close(done)
+
+	go serviceOnce(w, want, done)
+
+	got := w.GetAutoComplete(1, "a")
+	if len(got) != len(want) {
+		t.Fatalf("GetAutoComplete: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("result[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestGetAutoComplete_TimeoutNoWorker verifies that when nobody reads from the
+// channel GetAutoComplete returns nil within its timeout window.
+// We shorten the window via the 500 ms guard already in the code; the test
+// just confirms the return value is nil and that the call does not hang
+// indefinitely.
+func TestGetAutoComplete_TimeoutNoWorker(t *testing.T) {
+	// Not parallel — this test intentionally waits up to ~500 ms for the
+	// timeout to fire. Marking it parallel would only slow the suite down.
+
+	w := newTestWorld()
+
+	start := time.Now()
+	got := w.GetAutoComplete(99, "z")
+	elapsed := time.Since(start)
+
+	if got != nil {
+		t.Errorf("expected nil on timeout, got %v", got)
+	}
+	// Sanity: should not have returned instantly (< 1 ms) nor blocked forever.
+	if elapsed < 10*time.Millisecond {
+		t.Errorf("returned too quickly (%v); timeout guard may not be firing", elapsed)
+	}
+}
+
+// TestGetAutoComplete_WorkerDropsReply verifies the no-reply-after-send path:
+// a worker reads the request but does NOT send a reply. GetAutoComplete must
+// still return nil rather than hanging.
+func TestGetAutoComplete_WorkerDropsReply(t *testing.T) {
+	w := newTestWorld()
+	done := make(chan struct{})
+	defer close(done)
+
+	// Drain the request but never reply.
+	go func() {
+		select {
+		case <-w.autoCompleteReq:
+			// intentionally ignore req.reply
+		case <-done:
+		}
+	}()
+
+	got := w.GetAutoComplete(1, "drop")
+	if got != nil {
+		t.Errorf("expected nil when worker drops reply, got %v", got)
+	}
+}
+
+// TestGetAutoComplete_Concurrent verifies race-freedom when multiple goroutines
+// call GetAutoComplete simultaneously. Run with -race.
+func TestGetAutoComplete_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	const callers = 10
+	w := newTestWorld()
+	done := make(chan struct{})
+	defer close(done)
+
+	// Start a worker that services all requests sequentially.
+	go func() {
+		for {
+			select {
+			case req := <-w.autoCompleteReq:
+				select {
+				case req.reply <- []string{"look"}:
+				default:
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	results := make([][]string, callers)
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = w.GetAutoComplete(idx+1, "l")
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, r := range results {
+		if r == nil {
+			t.Errorf("caller %d: expected a result, got nil", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Eliminates the final data race in #24: GetAutoComplete called from connection goroutines reads shared game state without any lock.

## Changes
- `world.go`: New autoCompleteReq channel on World struct. Public GetAutoComplete is now goroutine-safe — sends a request to MainWorker and receives the result via a buffered reply channel with 500ms timeouts on both send and receive. The existing autocomplete logic is renamed to doGetAutoComplete and only called under the lock from within MainWorker.
- `world_autocomplete_test.go`: 4 tests covering reply received, timeout with no worker, timeout when worker drops reply, and concurrent callers.

## Test plan
- [x] All 4 new tests pass under -race
- [x] Full test suite passes with -race
- [x] Call site in main.go:527 works unchanged (public API preserved)

Completes targeted fixes for #24 (race 1 of 3). Races 2 and 3 landed in #50 and #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)