### PR TITLE
Fix weak tests flagged by adversarial review

### DIFF
--- a/internal/connections/connections_test.go
+++ b/internal/connections/connections_test.go
@@ -10,7 +10,7 @@ import (
 // TestGetAllConnectionIds verifies that GetAllConnectionIds returns exactly the
 // connections present in netConnections with no leading zero values.
 func TestGetAllConnectionIds(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates the package-level netConnections map.
 
 	// White-box: manipulate the package-level map directly under the lock.
 	lock.Lock()
@@ -164,11 +164,10 @@ func TestInputDisabled_Race(t *testing.T) {
 
 	wg.Wait()
 
-	// After all writers have finished, a read must return a valid bool (not torn).
-	result := cd.InputDisabled()
-	if result != true && result != false {
-		t.Errorf("InputDisabled() returned an unexpected value: %v", result)
-	}
+	// The primary correctness signal for this test is -race: if atomic.Bool
+	// were replaced with a plain bool, the race detector would flag the
+	// concurrent reads and writes above. No value assertion is needed here.
+	_ = cd.InputDisabled()
 }
 
 // TestInputDisabled_SetAndGet verifies the basic set-and-get semantics of

--- a/internal/rooms/roommanager_test.go
+++ b/internal/rooms/roommanager_test.go
@@ -1,8 +1,11 @@
 package rooms
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,8 +35,19 @@ func TestMoveToRoom_NilUser_DoesNotPanic(t *testing.T) {
 func TestSaveRoomTemplate_RoomNotInMemory_DoesNotPanic(t *testing.T) {
 	resetRoomManager()
 
-	// Room 500 is NOT in roomManager.rooms
-	// The nil deref happens at the range over roomBeingReplaced.Containers
+	// Set up a temp DataFiles path so the YAML write inside SaveRoomTemplate
+	// actually succeeds, allowing execution to reach the nil-deref path at
+	// save_and_load.go:185 (roomBeingReplaced := roomManager.rooms[...]).
+	tmp := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "rooms", "testzone"), 0755))
+	configs.SetTestDataFilesPath(tmp)
+
+	// Register the zone so GetZoneConfig returns a non-nil *ZoneConfig —
+	// otherwise the line `events.AddToQueue(events.RebuildMap{MapRootRoomId: cfg.RoomId})`
+	// would nil-deref before we reach the actual bug path.
+	roomManager.zones["testzone"] = &ZoneConfig{RoomId: 1}
+
+	// Room 500 is NOT in roomManager.rooms — triggers the nil lookup at line 185.
 	roomTpl := Room{
 		RoomId: 500,
 		Zone:   "testzone",
@@ -42,12 +56,11 @@ func TestSaveRoomTemplate_RoomNotInMemory_DoesNotPanic(t *testing.T) {
 		},
 	}
 
-	// This test exercises the nil path at save_and_load.go:185-188
-	// SaveRoomTemplate does filesystem I/O before reaching the nil deref,
-	// so this test will fail for a different reason (missing config/paths)
-	// unless the fix is applied first. The key assertion is: no panic from
-	// nil pointer dereference on roomBeingReplaced.
 	require.NotPanics(t, func() {
-		_ = SaveRoomTemplate(roomTpl)
+		err := SaveRoomTemplate(roomTpl)
+		require.NoError(t, err, "SaveRoomTemplate should succeed for a room not yet in memory")
 	})
+
+	// The fix inserts the room into memory as a side effect — verify it's there.
+	require.NotNil(t, roomManager.rooms[500], "after SaveRoomTemplate the new room should be in memory")
 }

--- a/internal/users/password_test.go
+++ b/internal/users/password_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/util"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -32,19 +33,19 @@ func bcryptHash(t *testing.T, pw string) string {
 // ---------------------------------------------------------------------------
 
 func TestUserRecord_SetPassword_StoresBcryptHash(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates global config via setupPasswordConfig.
+	setupPasswordConfig(t, 1, 72)
 
 	u := newTestUser()
-	// Set the hash directly to avoid config dependency, then verify the format
-	// produced by the real SetPassword path by calling bcrypt ourselves.
-	hash, err := bcrypt.GenerateFromPassword([]byte("hunter2"), bcrypt.DefaultCost)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	u.Password = string(hash)
+	require.NoError(t, u.SetPassword("hunter2"))
 
 	if !strings.HasPrefix(u.Password, "$2a$") && !strings.HasPrefix(u.Password, "$2b$") {
 		t.Errorf("expected bcrypt hash (prefix $2a$ or $2b$), got %q", u.Password)
+	}
+
+	// Sanity check: the stored hash should verify against the original password.
+	if err := bcrypt.CompareHashAndPassword([]byte(u.Password), []byte("hunter2")); err != nil {
+		t.Errorf("SetPassword did not store a verifiable bcrypt hash: %v", err)
 	}
 }
 
@@ -164,32 +165,25 @@ func TestUserRecord_PasswordMatches_MigratedHashWorksOnNextLogin(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUserRecord_SetPassword_DifferentHashesForSamePassword(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates global config via setupPasswordConfig.
+	setupPasswordConfig(t, 1, 72)
 
 	const pw = "shared-password"
 
-	h1, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	h2, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if string(h1) == string(h2) {
-		t.Error("two bcrypt hashes of the same password are identical — salt is not being applied")
-	}
-
-	// Both hashes must still verify against the original password.
 	u1, u2 := newTestUser(), newTestUser()
-	u1.Password, u2.Password = string(h1), string(h2)
+	require.NoError(t, u1.SetPassword(pw))
+	require.NoError(t, u2.SetPassword(pw))
 
+	if u1.Password == u2.Password {
+		t.Error("SetPassword produced identical hashes for the same password — salt is not being applied")
+	}
+
+	// Both records must still authenticate with the shared password.
 	if !u1.PasswordMatches(pw) {
-		t.Error("u1.PasswordMatches returned false")
+		t.Error("u1.PasswordMatches returned false after SetPassword")
 	}
 	if !u2.PasswordMatches(pw) {
-		t.Error("u2.PasswordMatches returned false")
+		t.Error("u2.PasswordMatches returned false after SetPassword")
 	}
 }
 

--- a/internal/web/viewconfig_test.go
+++ b/internal/web/viewconfig_test.go
@@ -134,22 +134,9 @@ func TestDoBasicAuth_AllowsLocalhostWithoutBlock(t *testing.T) {
 
 	protected := doBasicAuth(inner)
 
-	// Simulate many failures from a remote IP to trigger the rate limiter.
-	limiter := &webRateLimiter{attempts: make(map[string]*webAttemptInfo)}
-	for range 15 {
-		limiter.recordFailure("203.0.113.2")
-	}
-
-	// Localhost should never be blocked regardless of attempt count.
-	if limiter.isBlocked("127.0.0.1") {
-		t.Error("localhost should never be rate-limited")
-	}
-	if limiter.isBlocked("::1") {
-		t.Error("IPv6 loopback should never be rate-limited")
-	}
-
 	// A request from localhost without credentials should still get 401
-	// (auth required) but NOT 429 (rate limited).
+	// (auth required) but NOT 429 (rate limited), regardless of how many
+	// failures have been recorded globally.
 	req := httptest.NewRequest(http.MethodGet, "/admin/viewconfig", nil)
 	req.RemoteAddr = "127.0.0.1:9999"
 	rr := httptest.NewRecorder()

--- a/internal/web/xss_test.go
+++ b/internal/web/xss_test.go
@@ -1,59 +1,76 @@
 package web
 
-// TestXSSEscaping verifies that the web package uses html/template, which
-// auto-escapes user-controlled data before writing it into HTML output.
-// If this file is accidentally changed to import "text/template", the test
-// will fail because text/template does NOT escape HTML special characters.
+// These tests verify that the web package uses html/template (which
+// auto-escapes user-controlled data) rather than text/template (which
+// does not). They work by scanning the actual source files in this
+// package for the forbidden import — this is a direct regression guard
+// that fails if any web package file switches back to text/template.
 
 import (
-	"bytes"
-	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestXSSEscaping(t *testing.T) {
-	t.Parallel()
-
-	tmpl, err := template.New("test").Parse("<p>{{.}}</p>")
+// TestWebPackageUsesHtmlTemplate scans every non-test .go file in the web
+// package and verifies it does NOT import "text/template". This is the
+// actual XSS regression guard.
+func TestWebPackageUsesHtmlTemplate(t *testing.T) {
+	entries, err := os.ReadDir(".")
 	require.NoError(t, err)
 
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, "<script>alert(1)</script>")
-	require.NoError(t, err)
+	var scanned int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
 
-	output := buf.String()
-	// html/template escapes < and > to &lt; and &gt;
-	require.NotContains(t, output, "<script>", "html/template should escape raw <script> tags")
-	require.Contains(t, output, "&lt;script&gt;", "output should contain HTML-escaped content")
+		path := filepath.Join(".", name)
+		data, err := os.ReadFile(path)
+		require.NoError(t, err, "reading %s", path)
+
+		content := string(data)
+		require.NotContains(t, content, `"text/template"`,
+			"%s imports text/template — this is an XSS vulnerability. Use html/template instead.", name)
+
+		// We also want at least SOME file in the package to import html/template,
+		// otherwise the package isn't using templates at all and the guard is meaningless.
+		scanned++
+	}
+
+	require.Greater(t, scanned, 0, "no .go source files found in web package")
 }
 
-func TestXSSEscapingAttributes(t *testing.T) {
-	t.Parallel()
-
-	tmpl, err := template.New("test").Parse(`<input value="{{.}}">`)
+// TestWebPackageImportsHtmlTemplate verifies at least one source file
+// actually imports html/template, ensuring the regression guard above
+// has something to guard against.
+func TestWebPackageImportsHtmlTemplate(t *testing.T) {
+	entries, err := os.ReadDir(".")
 	require.NoError(t, err)
 
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, `"><script>alert(1)</script>`)
-	require.NoError(t, err)
+	var foundHtmlTemplate bool
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(".", name))
+		require.NoError(t, err)
+		if strings.Contains(string(data), `"html/template"`) {
+			foundHtmlTemplate = true
+			break
+		}
+	}
 
-	output := buf.String()
-	require.NotContains(t, output, "<script>", "html/template should escape attribute injection attempts")
-}
-
-func TestXSSEscapingAmpersand(t *testing.T) {
-	t.Parallel()
-
-	tmpl, err := template.New("test").Parse("<p>{{.}}</p>")
-	require.NoError(t, err)
-
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, "bread & butter")
-	require.NoError(t, err)
-
-	output := buf.String()
-	require.Contains(t, output, "&amp;", "html/template should escape & to &amp;")
-	require.NotContains(t, output, " & ", "unescaped ampersand should not appear in output")
+	require.True(t, foundHtmlTemplate, "no web package file imports html/template")
 }


### PR DESCRIPTION
## Summary
Three tests were rewritten to actually exercise the production code they claim to test. Plus minor test cleanups.

## Fixes
- **xss_test.go**: Was testing Go stdlib, not web package. Now scans web package source for text/template imports.
- **TestSaveRoomTemplate_RoomNotInMemory_DoesNotPanic**: Was returning early on I/O. Now sets up temp DataFiles path to reach the bug site.
- **TestUserRecord_SetPassword_***: Were never calling SetPassword. Now use the real function through the validation path.

## Paranoia checks
All three rewrites verified: tests fail with fixes reverted, pass with fixes restored.

## Minor cleanups
- Remove tautology assertion in connections_test.go
- Remove t.Parallel() from test that mutates global state
- Remove dead limiter block in viewconfig_test.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)