### PR TITLE
Don't rate-limit empty Authorization headers (fix admin self-lockout)

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -118,8 +118,14 @@ func doBasicAuth(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 
-		// Record the failed attempt before responding.
-		webAuthLimiter.RecordFailure(ip)
+		// Only record a failed attempt if credentials were actually provided.
+		// An empty Authorization header is part of the RFC 7617 challenge-response
+		// flow (browser must request without credentials first to receive 401 +
+		// WWW-Authenticate). Counting that as a failure would lock out legitimate
+		// admins on their initial page load.
+		if authHeader != "" {
+			webAuthLimiter.RecordFailure(ip)
+		}
 
 		// If the Authentication header is not present, is invalid, or the
 		// username or password is wrong, then set a WWW-Authenticate

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -1,10 +1,23 @@
 package web
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/ratelimit"
 )
+
+// TestMain initialises the global slog logger so that mudlog calls inside
+// production code do not panic with a nil slogInstance during tests.
+func TestMain(m *testing.M) {
+	mudlog.SetupLogger(nil, "", "", false)
+	os.Exit(m.Run())
+}
 
 // TestAuthCache_ConcurrentAccess verifies that concurrent reads and writes to
 // authCache do not produce a data race. Run with -race.
@@ -79,5 +92,64 @@ func TestPruneAuthCacheLocked_RemovesExpiredEntries(t *testing.T) {
 	}
 	if _, ok := snapshot["live"]; !ok {
 		t.Error("pruneAuthCacheLocked should have retained the live entry")
+	}
+}
+
+// TestDoBasicAuth_EmptyHeaderDoesNotRecordFailure verifies that credential-less
+// requests (the RFC 7617 initial challenge-response probe) do not increment the
+// rate-limiter's failure counter, preventing legitimate admins from locking
+// themselves out on initial page load.
+func TestDoBasicAuth_EmptyHeaderDoesNotRecordFailure(t *testing.T) {
+	// Reset the limiter for a clean baseline.
+	webAuthLimiter = ratelimit.New()
+	t.Cleanup(func() { webAuthLimiter = ratelimit.New() })
+
+	handler := doBasicAuth(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Send 10 requests with no Authorization header from the same non-localhost IP.
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/admin/", nil)
+		req.RemoteAddr = "203.0.113.5:12345"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		// Each should get 401, not 429.
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("request %d: expected 401, got %d", i, rr.Code)
+		}
+	}
+
+	// After 10 credential-less requests the limiter must NOT have blocked this IP.
+	if webAuthLimiter.IsBlocked("203.0.113.5") {
+		t.Error("expected IP to NOT be rate-limited after 10 credential-less requests")
+	}
+}
+
+// TestDoBasicAuth_WrongCredentialsRecordFailure verifies that requests carrying
+// an Authorization header with incorrect credentials do increment the failure
+// counter and eventually trigger the rate limiter.
+func TestDoBasicAuth_WrongCredentialsRecordFailure(t *testing.T) {
+	webAuthLimiter = ratelimit.New()
+	t.Cleanup(func() { webAuthLimiter = ratelimit.New() })
+
+	handler := doBasicAuth(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Send 5 requests with wrong credentials from the same IP.
+	// Progressive backoff: 5 failures → blocked (10 s).
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/admin/", nil)
+		req.RemoteAddr = "203.0.113.6:12345"
+		req.SetBasicAuth("nosuchuser", "nosuchpass")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+	}
+
+	// After 5 wrong-credential attempts the limiter SHOULD have blocked this IP.
+	if !webAuthLimiter.IsBlocked("203.0.113.6") {
+		t.Error("expected IP to be rate-limited after 5 wrong-credential requests")
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #76 — admin self-lockout when RecordFailure was called on every 401, including the credential-less first request required by RFC 7617.

## Fix
Only record a failure when `Authorization` header is present. Empty header is part of the expected challenge-response flow.

## Tests
- `TestDoBasicAuth_EmptyHeaderDoesNotRecordFailure` — 10 credential-less requests, IP not blocked. Paranoia check confirmed the test fails with the bug restored.
- `TestDoBasicAuth_WrongCredentialsRecordFailure` — 5 wrong-credential requests still correctly trigger the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)