### PR TITLE
Serialize telnet writes with writeMu to prevent deadline interleaving

### DIFF
--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -123,7 +123,7 @@ type ConnectionDetails struct {
 	lastInputTime     time.Time
 	conn              net.Conn
 	wsConn            *websocket.Conn
-	wsLock            sync.Mutex
+	writeMu           sync.Mutex // serializes Write() calls and protects SetWriteDeadline/Write/reset sequences
 	handlerMutex      sync.Mutex
 	inputHandlerNames []string
 	inputHandlers     []InputHandler
@@ -228,8 +228,8 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 	}
 
 	if cd.wsConn != nil {
-		cd.wsLock.Lock()
-		defer cd.wsLock.Unlock()
+		cd.writeMu.Lock()
+		defer cd.writeMu.Unlock()
 
 		// If this isn't caught and avoided, lots of stuff goes wrong.
 		// Websocket client complains, disconnects, error is rasised: close 1002 (protocol error): Invalid UTF-8 in text frame
@@ -251,6 +251,13 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 		}
 		return len(p), nil
 	}
+
+	// Serialize telnet writes: SetWriteDeadline + Write + reset must run as
+	// an atomic sequence, otherwise concurrent writers can overwrite each
+	// other's deadline state (a Write can end up running with a deadline
+	// set by another goroutine, or with no deadline at all after a reset).
+	cd.writeMu.Lock()
+	defer cd.writeMu.Unlock()
 
 	if err := cd.conn.SetWriteDeadline(time.Now().Add(writeDeadline)); err != nil {
 		return 0, err
@@ -325,7 +332,7 @@ func NewConnectionDetails(connId ConnectionId, c net.Conn, wsC *websocket.Conn, 
 		connectionId: connId,
 		conn:         c,
 		wsConn:       wsC,
-		wsLock:       sync.Mutex{},
+		writeMu:      sync.Mutex{},
 		// Track client settings
 		clientSettings: ClientSettings{
 			Display: DisplaySettings{ScreenWidth: 80, ScreenHeight: 40}, // Default to 80x40

--- a/internal/connections/connections_test.go
+++ b/internal/connections/connections_test.go
@@ -191,3 +191,120 @@ func TestInputDisabled_SetAndGet(t *testing.T) {
 		t.Error("InputDisabled() should return false after InputDisabled(false)")
 	}
 }
+
+// instrumentedConn wraps a net.Conn and records the ordered sequence of
+// SetWriteDeadline and Write calls so tests can verify that concurrent
+// callers never interleave their deadline+write sequences.
+//
+// The ConnectionDetails.Write() method on the telnet path performs three
+// ordered operations per call:
+//  1. SetWriteDeadline(future)
+//  2. conn.Write(payload)
+//  3. SetWriteDeadline(zero)   // reset
+//
+// If two goroutines run this sequence concurrently without a mutex, the
+// calls can interleave — e.g. A's SetWriteDeadline, B's SetWriteDeadline,
+// A's Write (which now runs with B's deadline). This test fails if any
+// interleaving is observed.
+type instrumentedConn struct {
+	mu     sync.Mutex
+	events []instrumentedEvent
+}
+
+type instrumentedEvent struct {
+	kind  string // "deadline-set", "deadline-zero", "write"
+	gor   int    // goroutine id (-1 if unknown)
+	delay time.Duration
+}
+
+func (c *instrumentedConn) record(kind string, gor int) {
+	c.mu.Lock()
+	c.events = append(c.events, instrumentedEvent{kind: kind, gor: gor})
+	c.mu.Unlock()
+}
+
+func (c *instrumentedConn) Read(p []byte) (int, error)        { return 0, nil }
+func (c *instrumentedConn) Close() error                      { return nil }
+func (c *instrumentedConn) LocalAddr() net.Addr               { return nil }
+func (c *instrumentedConn) RemoteAddr() net.Addr              { return nil }
+func (c *instrumentedConn) SetDeadline(t time.Time) error     { return nil }
+func (c *instrumentedConn) SetReadDeadline(t time.Time) error { return nil }
+
+func (c *instrumentedConn) SetWriteDeadline(t time.Time) error {
+	if t.IsZero() {
+		c.record("deadline-zero", -1)
+	} else {
+		c.record("deadline-set", -1)
+	}
+	// Small sleep to widen the race window — makes interleaving detectable
+	// if the mutex is missing.
+	time.Sleep(100 * time.Microsecond)
+	return nil
+}
+
+func (c *instrumentedConn) Write(p []byte) (int, error) {
+	c.record("write", -1)
+	time.Sleep(100 * time.Microsecond)
+	return len(p), nil
+}
+
+// TestWrite_TelnetConcurrentWritesSerialized verifies that ConnectionDetails.Write
+// serializes the SetWriteDeadline/Write/reset sequence. It uses a custom
+// instrumentedConn that records every call in order, then asserts that the
+// observed sequence is always of the form:
+//
+//	deadline-set, write, deadline-zero, deadline-set, write, deadline-zero, ...
+//
+// If the writeMu mutex is removed, concurrent goroutines will produce
+// interleaved patterns like:
+//
+//	deadline-set, deadline-set, write, deadline-zero, ...
+//
+// which the assertion below catches.
+func TestWrite_TelnetConcurrentWritesSerialized(t *testing.T) {
+	t.Parallel()
+
+	ic := &instrumentedConn{}
+	cd := &ConnectionDetails{conn: ic}
+
+	const goroutines = 10
+	const writesPerGoroutine = 5
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < writesPerGoroutine; j++ {
+				if _, err := cd.Write([]byte("payload\n")); err != nil {
+					t.Errorf("Write returned error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Expected pattern per Write: deadline-set, write, deadline-zero.
+	// With the mutex in place, these must appear contiguously for each call.
+	// Without the mutex, they interleave across goroutines and the pattern
+	// check below will find a violation.
+	totalWrites := goroutines * writesPerGoroutine
+	if len(ic.events) != totalWrites*3 {
+		t.Fatalf("expected %d events (3 per Write), got %d", totalWrites*3, len(ic.events))
+	}
+
+	for i := 0; i < len(ic.events); i += 3 {
+		if ic.events[i].kind != "deadline-set" {
+			t.Errorf("at event %d: expected 'deadline-set', got %q — telnet writes are not serialized by writeMu", i, ic.events[i].kind)
+			return
+		}
+		if ic.events[i+1].kind != "write" {
+			t.Errorf("at event %d: expected 'write', got %q — telnet writes are not serialized by writeMu", i+1, ic.events[i+1].kind)
+			return
+		}
+		if ic.events[i+2].kind != "deadline-zero" {
+			t.Errorf("at event %d: expected 'deadline-zero', got %q — telnet writes are not serialized by writeMu", i+2, ic.events[i+2].kind)
+			return
+		}
+	}
+}

--- a/internal/connections/heartbeat.go
+++ b/internal/connections/heartbeat.go
@@ -85,8 +85,8 @@ func (hm *heartbeatManager) runPingLoop() {
 }
 
 func (hm *heartbeatManager) writePing() error {
-	hm.cd.wsLock.Lock()
-	defer hm.cd.wsLock.Unlock()
+	hm.cd.writeMu.Lock()
+	defer hm.cd.writeMu.Unlock()
 
 	deadline := time.Now().Add(hm.config.WriteWait)
 	mudlog.Debug("Heartbeat::Ping", "connectionId", hm.cd.connectionId)


### PR DESCRIPTION
## Summary
Fixes #69 — telnet Write() had no synchronization around the SetWriteDeadline/Write/reset sequence. Concurrent writers could interleave, leaving writes with wrong deadlines.

## Fix
Renamed `wsLock` to `writeMu` (it now guards all write paths) and acquired it on the telnet path as well. Matches the WebSocket path's existing pattern.

## Test
`TestWrite_TelnetConcurrentWritesSerialized` uses a custom `instrumentedConn` that records every deadline and write call in order. Asserts the recorded sequence always matches the canonical `deadline-set → write → deadline-zero` pattern. Paranoia check confirmed: removing the mutex produces interleaving that the test catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)