### PR TITLE
Add health endpoint, data volume, and Docker healthcheck

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,9 @@ services:
       - type: volume
         source: log-volume
         target: /app/log
+      - type: volume
+        source: data-volume
+        target: /app/_datafiles
 
   busybox:
     container_name: "server-logs"
@@ -51,6 +54,7 @@ services:
 
 volumes:
   log-volume:
+  data-volume:
 
 networks:
   mud_network:

--- a/internal/web/health.go
+++ b/internal/web/health.go
@@ -1,0 +1,15 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	stats := GetStats()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":  "ok",
+		"players": len(stats.OnlineUsers),
+	})
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -292,6 +292,9 @@ func Listen(wg *sync.WaitGroup, webSocketHandler func(*websocket.Conn)) {
 
 	http.HandleFunc("/", serveTemplate)
 
+	// Health check endpoint for Docker/container probes
+	http.HandleFunc("GET /health", healthHandler)
+
 	// websocket upgrade
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 

--- a/provisioning/Dockerfile
+++ b/provisioning/Dockerfile
@@ -23,4 +23,7 @@ EXPOSE ${PORT}
 COPY --from=builder /src/${BIN} .
 COPY --from=builder /src/_datafiles ./_datafiles
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:80/health || exit 1
+
 ENTRYPOINT ["/bin/sh", "-c", "./${BIN}"]


### PR DESCRIPTION
## Summary

- Add `/health` HTTP endpoint returning `{"status":"ok","players":N}` for container liveness probes
- Add `data-volume` in `compose.yml` mounting `_datafiles/` so SQLite DB and config persist across restarts
- Add `HEALTHCHECK` instruction to Dockerfile using `wget` against the new endpoint

Closes #87

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go build ./...` compiles cleanly
- [ ] `curl http://localhost:80/health` returns `{"status":"ok","players":0}`
- [ ] `docker compose config` parses without errors
- [ ] Verify data-volume preserves game state across `docker compose down && docker compose up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)