### PR TITLE
Fix review findings from adversarial Go skills audit

### DIFF
--- a/internal/rooms/roommanager_test.go
+++ b/internal/rooms/roommanager_test.go
@@ -28,7 +28,7 @@ func resetRoomManager() {
 	roomManager.roomsWithUsers = make(map[int]int)
 	roomManager.roomsWithMobs = make(map[int]int)
 	roomManager.roomIdToFileCache = make(map[int]string)
-	userLookup = users.DefaultUserLookup()
+	SetUserLookup(users.DefaultUserLookup())
 }
 
 func TestMoveToRoom_NilUser_DoesNotPanic(t *testing.T) {

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -102,6 +102,10 @@ func NewRoom(zone string) *Room {
 			MapSymbol:   ``,
 			Exits:       make(map[string]exit.RoomExit),
 		},
+		RoomState: RoomState{
+			Containers:        make(map[string]Container),
+			LongTermDataStore: make(map[string]any),
+		},
 		players:       []int{},
 		visitors:      make(map[VisitorType]map[int]uint64),
 		tempDataStore: make(map[string]any),
@@ -119,6 +123,10 @@ func NewEmptyRoom() *Room {
 			Description: "This is an empty room that was never given a description.",
 			MapSymbol:   ``,
 			Exits:       make(map[string]exit.RoomExit),
+		},
+		RoomState: RoomState{
+			Containers:        make(map[string]Container),
+			LongTermDataStore: make(map[string]any),
 		},
 		players:       []int{},
 		visitors:      make(map[VisitorType]map[int]uint64),
@@ -821,7 +829,7 @@ func (r *Room) RemoveMob(mobInstanceId int) {
 	}
 }
 
-func (r *RoomState) AddItem(item items.Item, stash bool) {
+func (r *Room) AddItem(item items.Item, stash bool) {
 
 	item.Validate()
 
@@ -922,7 +930,7 @@ func (r *Room) GetRandomExit() (exitName string, roomId int) {
 	return ``, 0
 }
 
-func (r *RoomState) RemoveItem(i items.Item, stash bool) {
+func (r *Room) RemoveItem(i items.Item, stash bool) {
 
 	if stash {
 		for j := len(r.Stash) - 1; j >= 0; j-- {
@@ -942,7 +950,7 @@ func (r *RoomState) RemoveItem(i items.Item, stash bool) {
 
 }
 
-func (r *RoomState) GetAllFloorItems(stash bool) []items.Item {
+func (r *Room) GetAllFloorItems(stash bool) []items.Item {
 
 	found := []items.Item{}
 

--- a/internal/rooms/save_and_load_test.go
+++ b/internal/rooms/save_and_load_test.go
@@ -18,7 +18,7 @@ import (
 // setupTestRoom creates a template room on disk and an in-memory
 // persistence store. Returns the room ID and a cleanup function.
 // The caller must call resetRoomManager() before calling this.
-func setupTestRoom(t *testing.T, roomId int, zone string, tpl Room) {
+func setupTestRoom(t *testing.T, roomId int, zone string, tpl *Room) {
 	t.Helper()
 
 	tmp := t.TempDir()
@@ -28,7 +28,7 @@ func setupTestRoom(t *testing.T, roomId int, zone string, tpl Room) {
 
 	tpl.RoomId = roomId
 	tpl.Zone = zone
-	require.NoError(t, SaveRoomTemplate(tpl))
+	require.NoError(t, SaveRoomTemplate(*tpl))
 
 	s, err := persistence.Open("file::memory:?cache=shared")
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestSaveRoomInstance_EmbeddedFieldDiff(t *testing.T) {
 			Description: "Original description.",
 		},
 	}
-	setupTestRoom(t, 800, "testzone", tpl)
+	setupTestRoom(t, 800, "testzone", &tpl)
 
 	// Load the room and modify a RoomState field.
 	loaded := LoadRoomInstance(800)
@@ -98,7 +98,7 @@ func TestSaveRoomInstance_MultipleEmbeddedDiffs(t *testing.T) {
 			},
 		},
 	}
-	setupTestRoom(t, 801, "testzone", tpl)
+	setupTestRoom(t, 801, "testzone", &tpl)
 
 	loaded := LoadRoomInstance(801)
 	require.NotNil(t, loaded)
@@ -145,7 +145,7 @@ func TestSaveRoomInstance_TemplateOnlyRoom_NoOverlay(t *testing.T) {
 			Description: "Should produce no overlay.",
 		},
 	}
-	setupTestRoom(t, 802, "testzone", tpl)
+	setupTestRoom(t, 802, "testzone", &tpl)
 
 	loaded := LoadRoomInstance(802)
 	require.NotNil(t, loaded)
@@ -165,6 +165,7 @@ func TestSaveRoomInstance_TemplateOnlyRoom_NoOverlay(t *testing.T) {
 // and RoomState embeddings — all fields survive a round-trip and no
 // duplicate keys are produced.
 func TestYAMLRoundTrip_EmbeddedStructs(t *testing.T) {
+	t.Parallel()
 	original := Room{
 		RoomTemplate: RoomTemplate{
 			RoomId:      900,
@@ -230,7 +231,11 @@ func TestYAMLRoundTrip_EmbeddedStructs(t *testing.T) {
 	assert.Len(t, roundTripped.Items, 1)
 	assert.Equal(t, 10, roundTripped.Items[0].ItemId)
 	assert.Contains(t, roundTripped.Containers, "chest")
+	assert.Equal(t, 25, roundTripped.Containers["chest"].Gold)
 	assert.Len(t, roundTripped.Signs, 1)
+	assert.Equal(t, "hello", roundTripped.Signs[0].DisplayText)
+	assert.NotNil(t, roundTripped.LongTermDataStore)
+	assert.Len(t, roundTripped.LongTermDataStore, 1)
 
 	// Non-embedded fields
 	assert.Len(t, roundTripped.SpawnInfo, 1)

--- a/internal/rooms/userlookup.go
+++ b/internal/rooms/userlookup.go
@@ -1,32 +1,33 @@
 package rooms
 
 import (
-	"errors"
-
 	"github.com/GoMudEngine/GoMud/internal/users"
 )
 
-// userLookup is the active-user lookup backend for the rooms package.
-// Instead of importing users and calling the package-level functions
-// directly, rooms resolves users through this interface. This decouples
-// the runtime dependency and enables test stubs.
-//
-// Must be set via SetUserLookup before any room operations that need
-// to resolve users. The server main package initializes this during startup.
-var userLookup users.UserLookup
+// UserLookup is the minimal read-only interface for resolving active
+// users by their user ID. Defined in rooms (the consumer) per Go
+// convention: interfaces belong to the package that uses them.
+type UserLookup interface {
+	GetByUserId(userId int) *users.UserRecord
+}
+
+// Compile-time check: *users.ActiveUsers must satisfy UserLookup.
+var _ UserLookup = (*users.ActiveUsers)(nil)
+
+// userLookup is the active-user lookup backend. Set once during
+// startup via SetUserLookup before any concurrent room operations.
+// Not guarded by a mutex because the write happens-before any reads
+// (single-threaded initialization in main.go).
+var userLookup UserLookup
 
 // SetUserLookup installs the user lookup backend. Must be called
 // exactly once during server startup, before any room operations that
 // resolve users (e.g., MoveToRoom, SendText to players).
-func SetUserLookup(ul users.UserLookup) {
-	userLookup = ul
-}
-
-// requireUserLookup returns a descriptive error if the user lookup has
-// not been installed, rather than producing a nil pointer panic.
-func requireUserLookup() error {
-	if userLookup == nil {
-		return errors.New("rooms: user lookup not initialized (call rooms.SetUserLookup first)")
+// Panics if ul is nil — failing to provide a required dependency is a
+// programmer error and should be caught at startup.
+func SetUserLookup(ul UserLookup) {
+	if ul == nil {
+		panic("rooms: SetUserLookup called with nil")
 	}
-	return nil
+	userLookup = ul
 }

--- a/internal/rooms/userlookup_test.go
+++ b/internal/rooms/userlookup_test.go
@@ -3,22 +3,39 @@ package rooms
 import (
 	"testing"
 
+	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRequireUserLookup_NilReturnsError(t *testing.T) {
-	saved := userLookup
-	userLookup = nil
-	t.Cleanup(func() { userLookup = saved })
+// Tests in this file mutate package-level globals (userLookup).
+// Not safe for t.Parallel().
 
-	err := requireUserLookup()
-	assert.Error(t, err, "requireUserLookup must return an error when userLookup is nil")
-	assert.Contains(t, err.Error(), "user lookup not initialized")
+func TestSetUserLookup_NilPanics(t *testing.T) {
+	assert.Panics(t, func() { SetUserLookup(nil) },
+		"SetUserLookup(nil) must panic — missing dependency is a programmer error")
 }
 
-func TestRequireUserLookup_SetReturnsNil(t *testing.T) {
-	resetRoomManager() // sets userLookup via users.DefaultUserLookup()
+// fakeUserLookup is a test stub proving the interface enables
+// dependency injection without the real users package.
+type fakeUserLookup struct {
+	users map[int]*users.UserRecord
+}
 
-	err := requireUserLookup()
-	assert.NoError(t, err, "requireUserLookup must succeed when userLookup is set")
+func (f *fakeUserLookup) GetByUserId(userId int) *users.UserRecord {
+	return f.users[userId]
+}
+
+func TestSetUserLookup_WithStub(t *testing.T) {
+	saved := userLookup
+	t.Cleanup(func() { userLookup = saved })
+
+	fake := &fakeUserLookup{
+		users: map[int]*users.UserRecord{
+			1: {UserId: 1},
+		},
+	}
+	SetUserLookup(fake)
+
+	assert.NotNil(t, userLookup.GetByUserId(1))
+	assert.Nil(t, userLookup.GetByUserId(999))
 }

--- a/internal/users/repository.go
+++ b/internal/users/repository.go
@@ -1,21 +1,8 @@
 package users
 
-// UserLookup is the minimal read-only interface for resolving active users
-// by their user ID. Most consumers (rooms, mobcommands, scripting) only
-// need this single method.
-//
-// The concrete implementation is *ActiveUsers, which guards the lookup
-// with a read lock on userManager.
-type UserLookup interface {
-	GetByUserId(userId int) *UserRecord
-}
-
-// Compile-time check: *ActiveUsers must satisfy UserLookup.
-var _ UserLookup = (*ActiveUsers)(nil)
-
-// DefaultUserLookup returns the global active-user manager as a UserLookup.
-// Consumers that accept dependency injection should receive this during
-// initialization. If no override is provided, this is the default.
-func DefaultUserLookup() UserLookup {
+// DefaultUserLookup returns the global active-user manager.
+// The returned *ActiveUsers satisfies any single-method interface
+// requiring GetByUserId.
+func DefaultUserLookup() *ActiveUsers {
 	return userManager
 }

--- a/internal/users/repository_test.go
+++ b/internal/users/repository_test.go
@@ -7,14 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Compile-time check: *ActiveUsers must satisfy UserLookup.
-var _ UserLookup = (*ActiveUsers)(nil)
-
 func TestDefaultUserLookup_ReturnsWorkingSingleton(t *testing.T) {
 	ResetActiveUsers()
 
 	ul := DefaultUserLookup()
-	require.NotNil(t, ul, "DefaultUserLookup must return a non-nil implementation")
+	require.NotNil(t, ul, "DefaultUserLookup must return a non-nil *ActiveUsers")
 
 	// Unknown user returns nil.
 	assert.Nil(t, ul.GetByUserId(99999), "unknown userId must return nil")
@@ -38,12 +35,12 @@ func TestPackageLevelGetByUserId_DelegatesToSingleton(t *testing.T) {
 
 	// Both paths must return the same result.
 	fromPkgLevel := GetByUserId(7)
-	fromInterface := DefaultUserLookup().GetByUserId(7)
+	fromLookup := DefaultUserLookup().GetByUserId(7)
 
 	require.NotNil(t, fromPkgLevel)
-	require.NotNil(t, fromInterface)
-	assert.Same(t, fromPkgLevel, fromInterface,
-		"package-level GetByUserId and interface GetByUserId must return the same pointer")
+	require.NotNil(t, fromLookup)
+	assert.Same(t, fromPkgLevel, fromLookup,
+		"package-level GetByUserId and DefaultUserLookup().GetByUserId must return the same pointer")
 
 	// Both return nil for unknown users.
 	assert.Nil(t, GetByUserId(99999))


### PR DESCRIPTION
## Summary
Fixes issues found by adversarial review of PRs #93 and #95 against golang-structs-interfaces, golang-safety, golang-design-patterns, and golang-testing skills.

**Room struct split (#54) fixes:**
- Initialize `Containers` and `LongTermDataStore` maps in constructors to prevent nil-map write panics
- Move `AddItem`/`RemoveItem`/`GetAllFloorItems` back to `*Room` receiver for consistency — `RoomState` is now a pure data struct with no methods
- Strengthen YAML round-trip test with value assertions, add `t.Parallel()`
- Change `setupTestRoom` to accept `*Room`

**UserLookup interface (#55) fixes:**
- Move `UserLookup` interface from `users/` to `rooms/` — interfaces belong to the consumer package
- Change `DefaultUserLookup()` to return `*ActiveUsers` concrete type (accept interfaces, return structs)
- Add compile-time check in consumer package
- Add nil-panic guard to `SetUserLookup` with test
- Remove dead `requireUserLookup()` function and its tests
- Add `fakeUserLookup` stub test proving DI works
- Use `SetUserLookup()` API in test helper instead of direct global assignment

## Test plan
- [x] `TestSetUserLookup_NilPanics` — verifies nil guard panics
- [x] `TestSetUserLookup_WithStub` — proves DI with fake implementation
- [x] `TestYAMLRoundTrip_EmbeddedStructs` — strengthened value assertions + `t.Parallel()`
- [x] Compile-time check: `var _ UserLookup = (*users.ActiveUsers)(nil)`
- [x] All existing tests pass (`go test -race ./...`)
- [x] `go vet ./...` clean, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)